### PR TITLE
Meal Rebalance

### DIFF
--- a/Compatibility/sarg.alphagenes/Defs/ScariaZombies_CureMeals.xml
+++ b/Compatibility/sarg.alphagenes/Defs/ScariaZombies_CureMeals.xml
@@ -153,7 +153,7 @@
       </categories>
     </fixedIngredientFilter>
     <products>
-      <Taggerung_SCP_MinorCureMeal>25</Taggerung_SCP_MinorCureMeal>
+      <Taggerung_SCP_MinorCureMeal>30</Taggerung_SCP_MinorCureMeal>
     </products>
     <workSkill>Cooking</workSkill>
     <recipeUsers>


### PR DESCRIPTION
Previously cures removed an entire xenotype, but the cure meals (1 cure + 25 meals) individually remove one gene, however the fungoid xenotype is 27 genes, so it was more work for less overall cure.